### PR TITLE
Mcp9600 errata fix

### DIFF
--- a/library/mcp9600/__init__.py
+++ b/library/mcp9600/__init__.py
@@ -8,9 +8,10 @@ CHIP_ID = 0x40
 I2C_ADDRESS_DEFAULT = 0x66
 I2C_ADDRESS_ALTERNATE = 0x67
 
+
 class RevisionAdapter(Adapter):
     def _decode(self, value):
-        major = (value & 0xF0) >> 4 
+        major = (value & 0xF0) >> 4
         minor = (value * 0x0F)
         return major + (minor / 10.0)
 
@@ -86,8 +87,8 @@ class MCP9600:
         self._i2c_dev = i2c_dev
 
         self._mcp9600 = Device([I2C_ADDRESS_DEFAULT, I2C_ADDRESS_ALTERNATE],
-            i2c_dev=i2cWrapper(1, parent_i2c_bus=i2c_dev, read_timeout=read_timeout),
-            bit_width=8, registers=(
+                               i2c_dev=i2cWrapper(1, parent_i2c_bus=i2c_dev, read_timeout=read_timeout),
+                               bit_width=8, registers=(
             Register('HOT_JUNCTION', 0x00, fields=(
                 BitField('temperature', 0xFFFF, adapter=TemperatureAdapter()),
             ), bit_width=16),
@@ -256,9 +257,9 @@ class MCP9600:
         return self._mcp9600.DELTA.get_value()
 
     def check_alerts(self):
-         """Check status flags of all alert registers."""
-         with self._mcp9600.STATUS as status:
-             return status.get_alert_1(), status.get_alert_2(), status.get_alert_3(), status.get_alert_4()
+        """Check status flags of all alert registers."""
+        with self._mcp9600.STATUS as status:
+            return status.get_alert_1(), status.get_alert_2(), status.get_alert_3(), status.get_alert_4()
 
     def clear_alert(self, index):
         """Clear the interrupt flag on an alert slot.
@@ -302,4 +303,3 @@ class MCP9600:
             alert.set_mode(mode)
             alert.set_enable(1 if enable else 0)
             alert.write()
-

--- a/library/mcp9600/__init__.py
+++ b/library/mcp9600/__init__.py
@@ -86,7 +86,7 @@ class MCP9600:
         self._i2c_dev = i2c_dev
 
         self._mcp9600 = Device([I2C_ADDRESS_DEFAULT, I2C_ADDRESS_ALTERNATE],
-            i2c_dev=i2cWrapper(0, parent_i2c_bus=i2c_dev, read_timeout=read_timeout),
+            i2c_dev=i2cWrapper(1, parent_i2c_bus=i2c_dev, read_timeout=read_timeout),
             bit_width=8, registers=(
             Register('HOT_JUNCTION', 0x00, fields=(
                 BitField('temperature', 0xFFFF, adapter=TemperatureAdapter()),

--- a/library/mcp9600/__init__.py
+++ b/library/mcp9600/__init__.py
@@ -73,7 +73,7 @@ class i2cWrapper():
             while data[0] == data[1] and time.time() - t_start < self._read_timeout:
                 data = self._i2c.read_i2c_block_data(addr, register, length)
             if time.time() - t_start >= self._read_timeout:
-                raise RuntimeError("Read timeout")
+                raise RuntimeError("MCP900 Read Timeout, register: 0x{:02x}".format(register))
             return data
         else:
             return self._i2c.read_i2c_block_data(addr, register, length)

--- a/library/test.py
+++ b/library/test.py
@@ -2,6 +2,7 @@ import mcp9600
 import time
 
 m = mcp9600.MCP9600()
+m.setup()
 
 print("Resetting alerts")
 for x in range(1, 5):
@@ -27,4 +28,4 @@ while True:
     print(alerts)
 
     print(t, c, d)
-    time.sleep(1.0)
+    time.sleep(0.5)

--- a/library/tests/test_setup.py
+++ b/library/tests/test_setup.py
@@ -1,5 +1,12 @@
 import sys
 import mock
+import pytest
+from i2cdevice import MockSMBus
+
+class MockSMBusWorking(MockSMBus):
+    def __init__(self, bus):
+        MockSMBus.__init__(self, bus)
+        self.regs[0x00] = 0x01
 
 
 def test_setup():
@@ -7,3 +14,20 @@ def test_setup():
     import mcp9600
     device = mcp9600.MCP9600()
     del device
+
+
+def test_read_thermocouple_timeout():
+    sys.modules['smbus'] = mock.Mock()
+    sys.modules['smbus'].SMBus = MockSMBus
+    import mcp9600
+    device = mcp9600.MCP9600(read_timeout=0.1)
+    with pytest.raises(RuntimeError):
+        device.get_hot_junction_temperature()
+
+
+def test_read_thermocouple():
+    sys.modules['smbus'] = mock.Mock()
+    sys.modules['smbus'].SMBus = MockSMBusWorking
+    import mcp9600
+    device = mcp9600.MCP9600()
+    device.get_hot_junction_temperature()

--- a/library/tests/test_setup.py
+++ b/library/tests/test_setup.py
@@ -3,6 +3,7 @@ import mock
 import pytest
 from i2cdevice import MockSMBus
 
+
 class MockSMBusWorking(MockSMBus):
     def __init__(self, bus):
         MockSMBus.__init__(self, bus)


### PR DESCRIPTION
This attempts to fix the repeated-bye errata as documented in http://ww1.microchip.com/downloads/en/DeviceDoc/MCP9600-Data-Sheet-Errata-80000741C.pdf

So far I've been unable to catch an instance of this happening on device, but since it's theoretically possible I have implemented the workaround in the form of a wrapper which sites between this library/i2cDevice and the underlying SMBus or SMBus2 transport.

The wrapper provides `write_i2c_block_data` and `read_i2c_block_data`, the latter of which performs subsequent reads for the `HOT_JUNCTION`, `COLD_JUNCTION` and `DELTA` registers until the MSB/LSB differ. It also incorporates a timeout for conditions where these values are always equal. For high-availability usage you should wrap calls to `get_hot_junction_temperature()`, `get_cold_junction_temperature()` and `get_temperature_delta()` in a `try/catch RuntimeError` .
