### PR TITLE
Port to new i2cdevice API, various linting fixes and expanded test coverage

### DIFF
--- a/library/tests/test_features.py
+++ b/library/tests/test_features.py
@@ -1,0 +1,76 @@
+from i2cdevice import MockSMBus
+
+
+def test_get_hot_junction_temperature():
+    # Test the junction read and conversion formula
+    import mcp9600
+    smbus = MockSMBus(1, default_registers={
+        0x00: 1,
+        0x01: 96,
+        0x20: 0x40})
+    device = mcp9600.MCP9600(i2c_dev=smbus)
+    assert round(device.get_hot_junction_temperature(), 1) == 22.0
+
+
+def test_get_temperature_delta():
+    import mcp9600
+    smbus = MockSMBus(1, default_registers={
+        0x01: 1,
+        0x02: 96,
+        0x20: 0x40})
+    device = mcp9600.MCP9600(i2c_dev=smbus)
+    assert round(device.get_temperature_delta(), 1) == 22.0
+
+
+def test_get_cold_junction_temperature():
+    import mcp9600
+    smbus = MockSMBus(1, default_registers={
+        0x02: 1,
+        0x03: 96,
+        0x20: 0x40})
+    device = mcp9600.MCP9600(i2c_dev=smbus)
+    assert round(device.get_cold_junction_temperature(), 1) == 22.0
+
+
+def test_alert_flags():
+    import mcp9600
+    smbus = MockSMBus(1, default_registers={
+        0x04: 0b00000101,
+        0x20: 0x40})
+    device = mcp9600.MCP9600(i2c_dev=smbus)
+    assert device.check_alerts() == (1, 0, 1, 0)
+
+
+def test_alert_configure():
+    import mcp9600
+    smbus = MockSMBus(1, default_registers={
+        0x04: 0b00000101,
+        0x20: 0x40})
+    device = mcp9600.MCP9600(i2c_dev=smbus)
+
+    device.configure_alert(1,
+                           limit=25.25,  # Test to 1/4th degree precision
+                           hysteresis=0x99,
+                           clear_interrupt=True,
+                           monitor_junction=0,
+                           rise_fall=1,
+                           state=1,
+                           mode=1,
+                           enable=True)
+
+    assert smbus.regs[0x10:0x12] == [1, 148]
+    assert smbus.regs[0x0C] == 0x99
+    assert device.get_alert_hysteresis(1) == 0x99
+    assert device.get_alert_limit(1) == 25.25
+
+
+def test_alert_clear():
+    import mcp9600
+    smbus = MockSMBus(1, default_registers={
+        0x04: 0b00000101,
+        0x20: 0x40})
+    device = mcp9600.MCP9600(i2c_dev=smbus)
+
+    device.clear_alert(1)
+
+    assert smbus.regs[0x08] & 0b10000000 == 0b10000000

--- a/library/tests/test_setup.py
+++ b/library/tests/test_setup.py
@@ -1,9 +1,35 @@
-import sys
-import mock
+from i2cdevice import MockSMBus
+import pytest
 
 
 def test_setup():
-    sys.modules['smbus'] = mock.Mock()
+    # Test that library setup succeeds with correct CHIP ID
     import mcp9600
-    device = mcp9600.MCP9600()
+    device = mcp9600.MCP9600(i2c_dev=MockSMBus(1, default_registers={0x20: 0x40}))
     del device
+
+
+def test_setup_wrong_device():
+    # Test that reading the wrong CHIP ID throws a RuntimeError
+    import mcp9600
+    with pytest.raises(RuntimeError):
+        device = mcp9600.MCP9600(i2c_dev=MockSMBus(1, default_registers={0x20: 0x99}))
+        del device
+
+
+def test_setup_no_device():
+    class MockSMBusIOError(MockSMBus):
+        def read_i2c_block_data(self, i2c_address, register, length):
+            raise IOError("Simulated IOError")
+
+    import mcp9600
+    with pytest.raises(RuntimeError):
+        device = mcp9600.MCP9600(i2c_dev=MockSMBusIOError(1, default_registers={0x20: 0x99}))
+        del device
+
+
+def test_legacy_setup():
+    # Test a stub setup function exists despite it being depricated
+    import mcp9600
+    device = mcp9600.MCP9600(i2c_dev=MockSMBus(1, default_registers={0x20: 0x40}))
+    device.setup()


### PR DESCRIPTION
This changeset ports mcp9600-python to the proposed new i2cdevice API.

Included in this port are some indentation and linting fixes that were overlooked, plus expanded tests.

Details and rationale here - https://github.com/pimoroni/i2cdevice-python/pull/3